### PR TITLE
Replaces hyphen in version to use a regular one

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name": "jquery.layout",
-    "version": "1.3.0–rc30.79",
+    "version": "1.3.0-rc30.79",
     "authors": [
         "Fabrizio Balliano",
         "Kevin Dalman"


### PR DESCRIPTION
In the hope bower will recognize the version using `bower info jquery.layout`

I'd appreciate if you could also please change the tag in the repository to use a regular hyphen.
